### PR TITLE
Static link Windows.

### DIFF
--- a/openal/core.go
+++ b/openal/core.go
@@ -91,7 +91,7 @@ package openal
 
 /*
 #cgo linux LDFLAGS: -lopenal
-#cgo windows LDFLAGS: -lopenal32
+#cgo windows LDFLAGS: -l:libOpenAL32.a -lstdc++ -lole32 -lwinmm
 #cgo darwin LDFLAGS: -framework OpenAL
 #include <stdlib.h>
 #include "local.h"

--- a/openal/local.h
+++ b/openal/local.h
@@ -2,6 +2,7 @@
 #include<OpenAL/al.h>
 #include<OpenAL/alc.h>
 #else
+#define AL_LIBTYPE_STATIC
 #include<AL/al.h>
 #include<AL/alc.h>
 #endif


### PR DESCRIPTION
Windows users deal with distributing OpenAL DLLs, which is annoying.
Specifying the .a library forces compilers to compile statically.
Because the .dll.a library has some extra symbols that the .a doesn't,
those symbols need to be added back by linking dynamically to libstdc++,
libole32, and libwinmm. These are standard Windows DLLs,
and do not need to be distributed.